### PR TITLE
Fixed - String integer from REST should be parsed to pure Integer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ context.sails.police = function sailsContextLoader(req, res, next) {
 context.loadContextForRecord = function(req, res, next) {
   req.context.pk = actionUtil.requirePk(req);
 
-  if( !_.isNumber(req.context.pk) )
+  if( !_.isNumber(_.parseInt(req.context.pk)) )
     req.context.pk = null;
 
   req.context.isList = false;


### PR DESCRIPTION
NOTE: this plugin will work only for adapters which has Integer Primary Key, for example: would not work for MongoDB which for PK has UUID
